### PR TITLE
Support cljs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ Add the following to `~/.boot/profile.boot`:
 (boot.core/load-data-readers!)
 ```
 
+### Shadow-CLJS
+
+Add the following to `shadow-cljs.edn`:
+```clojure
+{:dependencies [hashp "0.1.2"]
+ :nrepl {:init-ns user}
+ :builds {:app {:devtools {:preloads [hashp.core]}}}}
+```
+
+Create a file `src/user.clj`:
+```clojure
+(ns user
+  (:require [hashp.core]))
+```
+
 ## License
 
 Copyright © 2019 James Reeves

--- a/project.clj
+++ b/project.clj
@@ -6,4 +6,6 @@
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/core.rrb-vector "0.1.1"]
                  [mvxcvi/puget "1.2.0"]
-                 [clj-stacktrace "0.2.8"]])
+                 [clj-stacktrace "0.2.8"]
+                 [net.cgrand/macrovich "0.2.1"]
+                 [zprint "0.5.3"]])

--- a/src/hashp/core.cljs
+++ b/src/hashp/core.cljs
@@ -1,0 +1,8 @@
+(ns hashp.core
+  (:require [zprint.core :as zprint]))
+
+(def prefix "#p")
+
+(def print-opts {:color? true
+                 :map {:lift-ns? true}
+                 :color-map {:nil :blue :none :blue}})


### PR DESCRIPTION
Some notable changes:

1. Since puget doesn't not support cljs, zprint is used to colorize the forms. Not sure if it's better to remove puget and use zprint in both cljs and clj.
2. While it is possible to use a single cljc file to serve both clj/cljs, that would make the code too complicated a mental burden, because at reader expansion time the cljc file would be treated as a clj file, while at runtime it's treated as a cljs ns, it's just too confusing. Besides it requires lots of reader conditionals. So imo it's better to keep it as a clj file, and keep the cljs runtime variables like `print-opts` in a cljs file.
3. The `case` macro of `net.cgrand/macrovich` is used in the `p*` function to make it generate clj/cljs code properly. Reader conditionals can't work here - this function is always compiled as clj code when being used as a data reader, so the cljs branch would never be used in this case. The `macrovich/case` macro could help this because it's a macro so it could generate different code for clj/cljs during macro expansion.
