### PR TITLE
Improve #p nil visibility for dark output contexts

### DIFF
--- a/src/hashp/core.clj
+++ b/src/hashp/core.clj
@@ -31,7 +31,9 @@
 (def print-opts
   (merge puget/*options*
          {:print-color    true
-          :namespace-maps true}))
+          :namespace-maps true
+          :color-scheme
+          {:nil [:bold :blue]}}))
 
 (defn p* [form]
   (let [orig-form (walk/postwalk hide-p-form form)]


### PR DESCRIPTION
The `[:bold :black]` colour choice inherited from `puget` is illegible in most dark theme output contexts. 