### PR TITLE
Resolve CLJS compile warnings arising from rewrite_clj dependency

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
-{:deps
- {org.clojure/clojure {:mvn/version "1.10.1"}
-  org.clojure/core.rrb-vector {:mvn/version "0.1.1"}
-  mvxcvi/puget {:mvn/version "1.3.0"}
-  clj-stacktrace/clj-stacktrace {:mvn/version "0.2.8"}
-  net.cgrand/macrovich {:mvn/version "0.2.1"}
-  zprint/zprint {:mvn/version "1.0.2"}}}
+{:paths ["src"]
+ :deps {org.clojure/clojure {:mvn/version "1.10.1"}
+        org.clojure/core.rrb-vector {:mvn/version "0.1.1"}
+        mvxcvi/puget {:mvn/version "1.3.0"}
+        clj-stacktrace/clj-stacktrace {:mvn/version "0.2.8"}
+        net.cgrand/macrovich {:mvn/version "0.2.1"}
+        zprint/zprint {:mvn/version "1.0.2"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,7 @@
+{:deps
+ {org.clojure/clojure {:mvn/version "1.10.1"}
+  org.clojure/core.rrb-vector {:mvn/version "0.1.1"}
+  mvxcvi/puget {:mvn/version "1.3.0"}
+  clj-stacktrace/clj-stacktrace {:mvn/version "0.2.8"}
+  net.cgrand/macrovich {:mvn/version "0.2.1"}
+  zprint/zprint {:mvn/version "1.0.2"}}}

--- a/project.clj
+++ b/project.clj
@@ -8,4 +8,4 @@
                  [mvxcvi/puget "1.3.0"]
                  [clj-stacktrace "0.2.8"]
                  [net.cgrand/macrovich "0.2.1"]
-                 [zprint "0.5.4"]])
+                 [zprint "1.0.2"]])


### PR DESCRIPTION
Note: inclusion of `deps.edn` allows me to reference my fork ahead of your next release:

```  
hashp/hashp {:git/url "https://github.com/codeasone/hashp.git"
             :sha "769b55ee9944aab17e54a64ac0034757a8777a44"}
```

Without this attempting to reference forks in deps.edn of referencing project leads to:

> Error building classpath. Manifest type not detected when finding deps for hashp/hashp in coordinate {:git/url "xxx", :sha "xxx"}