### PR TITLE
Add :require-macro in core.cljs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,19 @@ Add the following to `~/.boot/profile.boot`:
 Add the following to `shadow-cljs.edn`:
 ```clojure
 {:dependencies [hashp "0.2.0"]
- :nrepl {:init-ns user}
  :builds {:app {:devtools {:preloads [hashp.core]}}}}
 ```
 
-Create a file `src/user.clj`:
+Or alternatively via `~/.shadow-cljs/config.edn` and `--config-merge`:
+
+`~/.shadow-cljs/config.edn`:
 ```clojure
-(ns user
-  (:require [hashp.core]))
+{:dependencies [[hashp "0.2.0"]]}
+```
+
+Run:
+```
+shadow-cljs watch app --config-merge '{:devtools {:preloads [hashp.core]}}'
 ```
 
 ## License

--- a/src/hashp/core.cljs
+++ b/src/hashp/core.cljs
@@ -1,5 +1,6 @@
 (ns hashp.core
-  (:require [zprint.core :as zprint]))
+  (:require [zprint.core :as zprint])
+  (:require-macros hashp.core))
 
 (def prefix "#p")
 


### PR DESCRIPTION
In case it's generally useful, I found this worked well for me and makes
it straightword to run in a variety of shadow-cljs projects.

This seems to make it more straightforward to use via cljs, although it
contradicts the experience of @lucywang000 here
https://github.com/weavejester/hashp/pull/7#discussion_r387446427

I've modified the README to suit with an alternative method of running that
allows you to use without modifying project configuration.