### PR TITLE
Update puget to 1.3.2 to support Babashka

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.10.2"]
                  [org.clojure/core.rrb-vector "0.1.2"]
-                 [mvxcvi/puget "1.3.2"]
+                 [mvxcvi/puget "1.3.4"]
                  [clj-stacktrace "0.2.8"]
                  [net.cgrand/macrovich "0.2.1"]
                  [zprint "1.2.4"]])


### PR DESCRIPTION
Fix https://github.com/weavejester/hashp/issues/21#issuecomment-2661420341

This does not fix #21 proper though, it just allows it to run in Babashka.